### PR TITLE
Initial fixes for the polling transport within socketio.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
  <groupId>com.corundumstudio.socketio</groupId>
  <artifactId>netty-socketio</artifactId>
- <version>1.7.8-SNAPSHOT</version>
+ <version>1.7.8-HELPDOTCOM</version>
  <packaging>bundle</packaging>
  <name>NettySocketIO</name>
  <description>Socket.IO server implemented on Java</description>
@@ -130,7 +130,7 @@
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>4.0.25.Final</version>
   </dependency>
-  
+
   <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
@@ -305,9 +305,9 @@
                     com.corundumstudio.socketio;version="${project.version}",
                     com.corundumstudio.socketio.annotation;version="${project.version}",
                     com.corundumstudio.socketio.listener;version="${project.version}",
-                    com.corundumstudio.socketio.protocol;version="${project.version}",                       
-                    com.corundumstudio.socketio.store;version="${project.version}",                       
-                    com.corundumstudio.socketio.store.pubsub;version="${project.version}",                       
+                    com.corundumstudio.socketio.protocol;version="${project.version}",
+                    com.corundumstudio.socketio.store;version="${project.version}",
+                    com.corundumstudio.socketio.store.pubsub;version="${project.version}",
                    </Export-Package>
                </instructions>
            </configuration>

--- a/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
@@ -256,6 +256,14 @@ public class ClientHead {
         return currentTransport;
     }
 
+    /**
+        getChannel: Get the channel for a given transport.
+        @param Transport
+    */
+    public Channel getChannel(Transport transport) {
+        return ( channels.get(transport) == null ? null : channels.get(transport).getChannel() );
+    }
+
     public Queue<Packet> getPacketsQueue(Transport transport) {
         return channels.get(transport).getPacketsQueue();
     }

--- a/src/main/java/com/corundumstudio/socketio/handler/ClientsBox.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientsBox.java
@@ -23,7 +23,11 @@ import java.util.UUID;
 
 import com.corundumstudio.socketio.HandshakeData;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ClientsBox {
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final Map<UUID, ClientHead> uuid2clients = PlatformDependent.newConcurrentHashMap();
     private final Map<Channel, ClientHead> channel2clients = PlatformDependent.newConcurrentHashMap();
@@ -63,4 +67,10 @@ public class ClientsBox {
         return channel2clients.get(channel);
     }
 
+    public void dumpStats() {
+        log.info("Memory Sizes: " +
+            "uuid2clients=" + uuid2clients.keySet().size() + ", " +
+            "channel2clients=" + channel2clients.keySet().size()
+        );
+    }
 }

--- a/src/main/java/com/corundumstudio/socketio/handler/ResponseLogic.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ResponseLogic.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+
+public class ResponseLogic {
+    public static void sendError(
+        ChannelHandlerContext ctx, String code, String message, String origin
+    ) {
+        HttpResponse res = new DefaultFullHttpResponse(
+            HTTP_1_1, HttpResponseStatus.BAD_REQUEST,
+            Unpooled.copiedBuffer(
+                "{code: '" + code + "', message: '" + message + "'}", // GSONBuilder.generatObject
+                CharsetUtil.UTF_8
+            )
+        );
+
+        HttpHeaders hdrs = res.headers();
+        hdrs.add("Content-Type", "application/json");
+
+        if ( origin != null ) {
+            hdrs.add("Access-Control-Allow-Credentials", "true");
+            hdrs.add("Access-Control-Allow-Origin", origin);
+        } else {
+            hdrs.add("Access-Control-Allow-Origin", "*");
+        }
+
+        ctx.channel().writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/transport/PollingTransport.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/PollingTransport.java
@@ -41,6 +41,7 @@ import com.corundumstudio.socketio.handler.AuthorizeHandler;
 import com.corundumstudio.socketio.handler.ClientHead;
 import com.corundumstudio.socketio.handler.ClientsBox;
 import com.corundumstudio.socketio.handler.EncoderHandler;
+import com.corundumstudio.socketio.handler.ResponseLogic;
 import com.corundumstudio.socketio.messages.PacketsMessage;
 import com.corundumstudio.socketio.messages.XHROptionsMessage;
 import com.corundumstudio.socketio.messages.XHRPostMessage;
@@ -97,6 +98,14 @@ public class PollingTransport extends ChannelInboundHandlerAdapter {
                         handleMessage(req, sessionId, queryDecoder, ctx);
                     } else {
                         // first connection
+                        if ( req.getMethod().equals("GET") ) { // first connection cannot be GET
+                            ResponseLogic.sendError(
+                                ctx, "BAD_HANDSHAKE_METHOD", "Bad handshake method", origin
+                            );
+                            req.release();
+                            return;
+                        }
+
                         ClientHead client = ctx.channel().attr(ClientHead.CLIENT).get();
                         handleMessage(req, client.getSessionId(), queryDecoder, ctx);
                     }


### PR DESCRIPTION
This addresses a memory leak, and adds some monitoring by adding a thread to watch the sizes of the core maps.
ResponseLogic provides a "unified" error handler that adds the appropriate CORS headers.
PollingTransport should send an error if the first request is a GET.
AuthorizeHandler now will send an UNKNOWN_SID if one is provided but not actually in cache.
The downside to this is this check has to be made at every layer in the pipeline, so we will still see "error" log messages in the case of a race condition.
Added a simple "ClientHead" channel retrieval method.